### PR TITLE
消息框内边框和阴影设置为 0

### DIFF
--- a/AssFile/AssFile.c
+++ b/AssFile/AssFile.c
@@ -1147,7 +1147,7 @@ int writeAss(const char *const fileName, DANMAKU *danmakuHead,
         
         fprintf(fptr, "\nStyle: %s,%s,%d,%s,%s,%s,%s,%d,%d,%d,%d,%.2f,%.2f,%.2f,%.2f,%d,%d,%d,%d,%d,%d,%d,%d",
                      "message_box", config.fontname, config.msgboxFontsize, "&H00FFFFFF", "&H00FFFFFF", "&H00000000", "&H1E6A5149",
-                     bold, 0, 0, 0, 100.00, 100.00, 0.00, 0.00, 1, config.outline, config.shadow, 7,
+                     bold, 0, 0, 0, 100.00, 100.00, 0.00, 0.00, 1, 0, 0, 7,
                      0, 0, 0, 1
                );
         


### PR DESCRIPTION
将消息框内边框和阴影设置为 0 出于两点考虑：
1. 边框颜色应该和文字颜色区别开以凸显文字部分，目前的颜色设置（文字深色边框黑色）会混淆边框和文字，而背景颜色已经足以凸显文字
2. 字号越大，相应的边框和阴影也应该越宽，目前弹幕和消息框的文字大小分辨设置，阴影和边框也应该分别设置或者根据比例换算
目前边框和阴影设置为 0 效果看起来更好一点，后续可以考虑更精细的控制消息框内的样式