### PR TITLE
修改消息框中文字的描边和阴影

### DIFF
--- a/AssFile/AssFile.c
+++ b/AssFile/AssFile.c
@@ -2981,7 +2981,7 @@ int printMessage(FILE *filePtr,
         fprintf(filePtr, "\nDialogue: 0,");
         printTime(filePtr, startTime, ",");
         printTime(filePtr, endTime, ",");
-        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s%s\\shad0\\p1}m %d %d b %d %d %d %d %d %d "
+        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s%s\\shad0\\p1\\bord0\\shadow0}m %d %d b %d %d %d %d %d %d "
             "l %d %d b %d %d %d %d %d %d l %d %d l %d %d",
             getActionStr(actionStr, 0, 0, startPosX, startPosY, endPosX, endPosY), /* 移动指令 */
             effect, /* 补充特效 */
@@ -2998,7 +2998,7 @@ int printMessage(FILE *filePtr,
         fprintf(filePtr, "\nDialogue: 0,");
         printTime(filePtr, startTime, ",");
         printTime(filePtr, endTime, ",");
-        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s\\shad0\\p1%s}m %d %d l %d %d l %d %d b %d %d %d %d %d %d l %d %d"
+        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s\\shad0\\p1%s\\bord0\\shadow0}m %d %d l %d %d l %d %d b %d %d %d %d %d %d l %d %d"
             "b %d %d %d %d %d %d",
             getActionStr(actionStr, 0, topBoxHeight, startPosX, startPosY, endPosX, endPosY), /* 移动指令 */
             effect, /* 补充特效 */
@@ -3075,7 +3075,7 @@ int printMessage(FILE *filePtr,
         fprintf(filePtr, "\nDialogue: 0,");
         printTime(filePtr, startTime, ",");
         printTime(filePtr, endTime, ",");
-        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s%s\\shad0\\p1}m %d %d b %d %d %d %d %d %d "
+        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s%s\\shad0\\p1\\bord0\\shadow0}m %d %d b %d %d %d %d %d %d "
             "l %d %d b %d %d %d %d %d %d l %d %d b %d %d %d %d %d %d l %d %d b %d %d %d %d %d %d",
             getActionStr(actionStr, 0, 0, startPosX, startPosY, endPosX, endPosY), /* 移动指令 */
             effect, /* 补充特效 */

--- a/AssFile/AssFile.c
+++ b/AssFile/AssFile.c
@@ -1127,7 +1127,8 @@ int writeAss(const char *const fileName, DANMAKU *danmakuHead,
                   "Collisions: Normal\n"
                   "PlayResX: %d\n"
                   "PlayResY: %d\n"
-                  "Timer: 100.0000\n\n",
+                  "Timer: 100.0000\n"
+                  "ScaledBorderAndShadow: yes\n\n",
             config.resolution.x, config.resolution.y
            );
     
@@ -1156,47 +1157,48 @@ int writeAss(const char *const fileName, DANMAKU *danmakuHead,
         
         
         /* 样式设定 */
-        fprintf(fptr, "\nStyle: %s,%s,%d,%s,%s,%s,%s,%d,%d,%d,%d,%.2f,%.2f,%.2f,%.2f,%d,%d,%d,%d,%d,%d,%d,%d",
+        fprintf(fptr, "\nStyle: %s,%s,%d,%s,%s,%s,%s,%d,%d,%d,%d,%.2f,%.2f,%.2f,%.2f,%d,%.1f,%.1f,%d,%d,%d,%d,%d",
                      "R2L", config.fontname, config.fontsize, primaryColour, "&H00FFFFFF", "&H00000000", "&H1E6A5149",
                      bold, 0, 0, 0, 100.00, 100.00, 0.00, 0.00, 1, config.outline, config.shadow, 8,
                      0, 0, 0, 1
                );
         
-        fprintf(fptr, "\nStyle: %s,%s,%d,%s,%s,%s,%s,%d,%d,%d,%d,%.2f,%.2f,%.2f,%.2f,%d,%d,%d,%d,%d,%d,%d,%d",
+        fprintf(fptr, "\nStyle: %s,%s,%d,%s,%s,%s,%s,%d,%d,%d,%d,%.2f,%.2f,%.2f,%.2f,%d,%.1f,%.1f,%d,%d,%d,%d,%d",
                      "L2R", config.fontname, config.fontsize, primaryColour, "&H00FFFFFF", "&H00000000", "&H1E6A5149",
                      bold, 0, 0, 0, 100.00, 100.00, 0.00, 0.00, 1, config.outline, config.shadow, 8,
                      0, 0, 0, 1
                );
         
-        fprintf(fptr, "\nStyle: %s,%s,%d,%s,%s,%s,%s,%d,%d,%d,%d,%.2f,%.2f,%.2f,%.2f,%d,%d,%d,%d,%d,%d,%d,%d",
+        fprintf(fptr, "\nStyle: %s,%s,%d,%s,%s,%s,%s,%d,%d,%d,%d,%.2f,%.2f,%.2f,%.2f,%d,%.1f,%.1f,%d,%d,%d,%d,%d",
                      "TOP", config.fontname, config.fontsize, primaryColour, "&H00FFFFFF", "&H00000000", "&H1E6A5149",
                      bold, 0, 0, 0, 100.00, 100.00, 0.00, 0.00, 1, config.outline, config.shadow, 8,
                      0, 0, 0, 1
                );
         
-        fprintf(fptr, "\nStyle: %s,%s,%d,%s,%s,%s,%s,%d,%d,%d,%d,%.2f,%.2f,%.2f,%.2f,%d,%d,%d,%d,%d,%d,%d,%d",
+        fprintf(fptr, "\nStyle: %s,%s,%d,%s,%s,%s,%s,%d,%d,%d,%d,%.2f,%.2f,%.2f,%.2f,%d,%.1f,%.1f,%d,%d,%d,%d,%d",
                      "BTM", config.fontname, config.fontsize, primaryColour, "&H00FFFFFF", "&H00000000", "&H1E6A5149",
                      bold, 0, 0, 0, 100.00, 100.00, 0.00, 0.00, 1, config.outline, config.shadow, 8,
                      0, 0, 0, 1
                );
         
-        fprintf(fptr, "\nStyle: %s,%s,%d,%s,%s,%s,%s,%d,%d,%d,%d,%.2f,%.2f,%.2f,%.2f,%d,%d,%d,%d,%d,%d,%d,%d",
+        fprintf(fptr, "\nStyle: %s,%s,%d,%s,%s,%s,%s,%d,%d,%d,%d,%.2f,%.2f,%.2f,%.2f,%d,%.1f,%.1f,%d,%d,%d,%d,%d",
                      "SP", config.fontname, config.fontsize, "&H00FFFFFF", "&H00FFFFFF", "&H00000000", "&H1E6A5149",
                      bold, 0, 0, 0, 100.00, 100.00, 0.00, 0.00, 1, config.outline, config.shadow, 7,
                      0, 0, 0, 1
                );
-        
-        fprintf(fptr, "\nStyle: %s,%s,%d,%s,%s,%s,%s,%d,%d,%d,%d,%.2f,%.2f,%.2f,%.2f,%d,%d,%d,%d,%d,%d,%d,%d",
+        float msgboxOutline = config.outline * config.msgboxFontsize / config.fontsize;
+        float msgboxShadow = config.shadow * config.msgboxFontsize / config.fontsize;
+        fprintf(fptr, "\nStyle: %s,%s,%d,%s,%s,%s,%s,%d,%d,%d,%d,%.2f,%.2f,%.2f,%.2f,%d,%.1f,%.1f,%d,%d,%d,%d,%d",
                      "message_box", config.fontname, config.msgboxFontsize, "&H00FFFFFF", "&H00FFFFFF", "&H00000000", "&H1E6A5149",
-                     bold, 0, 0, 0, 100.00, 100.00, 0.00, 0.00, 1, 0, 0, 7,
+                     bold, 0, 0, 0, 100.00, 100.00, 0.00, 0.00, 1, msgboxOutline, msgboxShadow, 7,
                      0, 0, 0, 1
                );
         
         if (config.statmode != 0)
         {
-            fprintf(fptr, "\nStyle: %s,%s,%d,%s,%s,%s,%s,%d,%d,%d,%d,%.2f,%.2f,%.2f,%.2f,%d,%d,%d,%d,%d,%d,%d,%d",
+            fprintf(fptr, "\nStyle: %s,%s,%d,%s,%s,%s,%s,%d,%d,%d,%d,%.2f,%.2f,%.2f,%.2f,%d,%.1f,%.1f,%d,%d,%d,%d,%d",
                      "danmakuFactory_stat", config.fontname, config.fontsize, "&H35FFFFFF", "&H35FFFFFF", "&H35000000", "&H356A5149",
-                     0, 0, 0, 0, 100.00, 100.00, 0.00, 0.00, 0, 0, 0, 5,
+                     0, 0, 0, 0, 100.00, 100.00, 0.00, 0.00, 0, 0.0, 0.0, 5,
                      0, 0, 0, 1
                     );
         }
@@ -3013,7 +3015,7 @@ int printMessage(FILE *filePtr,
         fprintf(filePtr, "\nDialogue: 1,");
         printTime(filePtr, startTime, ",");
         printTime(filePtr, endTime, ",");
-        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s%s\\fs%d\\b1\\q2}%s",
+        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s%s\\fs%d\\b1\\q2\\bord0\\shadow0}%s",
             getActionStr(actionStr, radius/2, radius/3, startPosX, startPosY, endPosX, endPosY), /* 移动指令 */
             effect, /* 补充特效 */
             userIDColor, /* 颜色 */
@@ -3025,7 +3027,7 @@ int printMessage(FILE *filePtr,
         fprintf(filePtr, "\nDialogue: 1,");
         printTime(filePtr, startTime, ",");
         printTime(filePtr, endTime, ",");
-        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s%s\\fs%d\\q2}SuperChat CNY %d",
+        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s%s\\fs%d\\q2\\bord0\\shadow0}SuperChat CNY %d",
             getActionStr(actionStr, radius/2, fontSize+radius/3, startPosX, startPosY, endPosX, endPosY), /* 移动指令 */
             effect, /* 补充特效 */
             textColor, /* 颜色 */
@@ -3037,7 +3039,7 @@ int printMessage(FILE *filePtr,
         fprintf(filePtr, "\nDialogue: 1,");
         printTime(filePtr, startTime, ",");
         printTime(filePtr, endTime, ",");
-        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s\\c&HFFFFFF\\q2}%s",
+        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s\\c&HFFFFFF\\q2\\bord0\\shadow0}%s",
             getActionStr(actionStr, radius/2, topBoxHeight, startPosX, startPosY, endPosX, endPosY), /* 移动指令 */
             effect, /* 补充特效 */
             scMsgStr /* SC内容 */
@@ -3092,7 +3094,7 @@ int printMessage(FILE *filePtr,
         fprintf(filePtr, "\nDialogue: 1,");
         printTime(filePtr, startTime, ",");
         printTime(filePtr, endTime, ",");
-        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s%s\\fs%d\\q2}%s",
+        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s%s\\fs%d\\q2\\bord0\\shadow0}%s",
             getActionStr(actionStr, radius/2, radius/3, startPosX, startPosY, endPosX, endPosY), /* 移动指令 */
             effect, /* 补充特效 */
             userIDColor, /* 颜色 */
@@ -3104,7 +3106,7 @@ int printMessage(FILE *filePtr,
         fprintf(filePtr, "\nDialogue: 1,");
         printTime(filePtr, startTime, ",");
         printTime(filePtr, endTime, ",");
-        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s%s\\fs%d\\q2}Welcome new %s!",
+        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s%s\\fs%d\\q2\\bord0\\shadow0}Welcome new %s!",
             getActionStr(actionStr, radius/2, fontSize+radius/3, startPosX, startPosY, endPosX, endPosY), /* 移动指令 */
             effect, /* 补充特效 */
             textColor, /* 颜色 */

--- a/AssFile/AssFile.c
+++ b/AssFile/AssFile.c
@@ -2981,7 +2981,7 @@ int printMessage(FILE *filePtr,
         fprintf(filePtr, "\nDialogue: 0,");
         printTime(filePtr, startTime, ",");
         printTime(filePtr, endTime, ",");
-        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s%s\\shad0\\p1\\bord0\\shadow0}m %d %d b %d %d %d %d %d %d "
+        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s%s\\p1\\bord0\\shad0}m %d %d b %d %d %d %d %d %d "
             "l %d %d b %d %d %d %d %d %d l %d %d l %d %d",
             getActionStr(actionStr, 0, 0, startPosX, startPosY, endPosX, endPosY), /* 移动指令 */
             effect, /* 补充特效 */
@@ -2998,7 +2998,7 @@ int printMessage(FILE *filePtr,
         fprintf(filePtr, "\nDialogue: 0,");
         printTime(filePtr, startTime, ",");
         printTime(filePtr, endTime, ",");
-        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s\\shad0\\p1%s\\bord0\\shadow0}m %d %d l %d %d l %d %d b %d %d %d %d %d %d l %d %d"
+        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s\\p1%s\\bord0\\shad0}m %d %d l %d %d l %d %d b %d %d %d %d %d %d l %d %d"
             "b %d %d %d %d %d %d",
             getActionStr(actionStr, 0, topBoxHeight, startPosX, startPosY, endPosX, endPosY), /* 移动指令 */
             effect, /* 补充特效 */
@@ -3015,7 +3015,7 @@ int printMessage(FILE *filePtr,
         fprintf(filePtr, "\nDialogue: 1,");
         printTime(filePtr, startTime, ",");
         printTime(filePtr, endTime, ",");
-        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s%s\\fs%d\\b1\\q2\\bord0\\shadow0}%s",
+        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s%s\\fs%d\\b1\\q2\\bord0\\shad0}%s",
             getActionStr(actionStr, radius/2, radius/3, startPosX, startPosY, endPosX, endPosY), /* 移动指令 */
             effect, /* 补充特效 */
             userIDColor, /* 颜色 */
@@ -3027,7 +3027,7 @@ int printMessage(FILE *filePtr,
         fprintf(filePtr, "\nDialogue: 1,");
         printTime(filePtr, startTime, ",");
         printTime(filePtr, endTime, ",");
-        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s%s\\fs%d\\q2\\bord0\\shadow0}SuperChat CNY %d",
+        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s%s\\fs%d\\q2\\bord0\\shad0}SuperChat CNY %d",
             getActionStr(actionStr, radius/2, fontSize+radius/3, startPosX, startPosY, endPosX, endPosY), /* 移动指令 */
             effect, /* 补充特效 */
             textColor, /* 颜色 */
@@ -3039,7 +3039,7 @@ int printMessage(FILE *filePtr,
         fprintf(filePtr, "\nDialogue: 1,");
         printTime(filePtr, startTime, ",");
         printTime(filePtr, endTime, ",");
-        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s\\c&HFFFFFF\\q2\\bord0\\shadow0}%s",
+        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s\\c&HFFFFFF\\q2\\bord0\\shad0}%s",
             getActionStr(actionStr, radius/2, topBoxHeight, startPosX, startPosY, endPosX, endPosY), /* 移动指令 */
             effect, /* 补充特效 */
             scMsgStr /* SC内容 */
@@ -3075,7 +3075,7 @@ int printMessage(FILE *filePtr,
         fprintf(filePtr, "\nDialogue: 0,");
         printTime(filePtr, startTime, ",");
         printTime(filePtr, endTime, ",");
-        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s%s\\shad0\\p1\\bord0\\shadow0}m %d %d b %d %d %d %d %d %d "
+        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s%s\\p1\\bord0\\shad0}m %d %d b %d %d %d %d %d %d "
             "l %d %d b %d %d %d %d %d %d l %d %d b %d %d %d %d %d %d l %d %d b %d %d %d %d %d %d",
             getActionStr(actionStr, 0, 0, startPosX, startPosY, endPosX, endPosY), /* 移动指令 */
             effect, /* 补充特效 */
@@ -3094,7 +3094,7 @@ int printMessage(FILE *filePtr,
         fprintf(filePtr, "\nDialogue: 1,");
         printTime(filePtr, startTime, ",");
         printTime(filePtr, endTime, ",");
-        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s%s\\fs%d\\q2\\bord0\\shadow0}%s",
+        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s%s\\fs%d\\q2\\bord0\\shad0}%s",
             getActionStr(actionStr, radius/2, radius/3, startPosX, startPosY, endPosX, endPosY), /* 移动指令 */
             effect, /* 补充特效 */
             userIDColor, /* 颜色 */
@@ -3106,7 +3106,7 @@ int printMessage(FILE *filePtr,
         fprintf(filePtr, "\nDialogue: 1,");
         printTime(filePtr, startTime, ",");
         printTime(filePtr, endTime, ",");
-        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s%s\\fs%d\\q2\\bord0\\shadow0}Welcome new %s!",
+        fprintf(filePtr, "message_box,,0000,0000,0000,,{%s%s%s\\fs%d\\q2\\bord0\\shad0}Welcome new %s!",
             getActionStr(actionStr, radius/2, fontSize+radius/3, startPosX, startPosY, endPosX, endPosY), /* 移动指令 */
             effect, /* 补充特效 */
             textColor, /* 颜色 */

--- a/Config/Config.c
+++ b/Config/Config.c
@@ -221,11 +221,11 @@ CONFIG readConfig(const char *const configFileName, const CONFIG defaultConfig)
         }
         else if (strcmp("outline", key) == 0)
         {
-            configOnfile.outline = atoi(value);
+            configOnfile.outline = atof(value);
         }
         else if (strcmp("shadow", key) == 0)
         {
-            configOnfile.shadow = atoi(value);
+            configOnfile.shadow = atof(value);
         }
         else if (strcmp("bold", key) == 0)
         {
@@ -302,8 +302,8 @@ BOOL writeConfig(const char *const configFileName, const CONFIG newConfig)
             "    \"fontname\": \"%s\",\n"
             "    \"fontsize\": %d,\n"
             "    \"opacity\": %d,\n"
-            "    \"outline\": %d,\n"
-            "    \"shadow\": %d,\n"
+            "    \"outline\": %.1f,\n"
+            "    \"shadow\": %.1f,\n"
             "    \"displayArea\": %f,\n"
             "    \"scrollArea\": %f,\n"
             "    \"bold\": %s,\n"
@@ -479,16 +479,16 @@ void printConfig(CONFIG config)
         printf("(unlimit)");
     }
     
-    printf(" | Fontname: \"%s\" | Fontsize: %d | Opacity: %d | Outline: %d",
+    printf(" | Fontname: \"%s\" | Fontsize: %d | Opacity: %d | Outline: %.1f",
            config.fontname, config.fontsize, config.opacity, config.outline
           );
-    if (config.outline == 0)
+    if (fabs(config.outline) < EPS)
     {
         printf("(disable)");
     }
     
-    printf(" | Shadow: %d", config.shadow);
-    if (config.shadow == 0)
+    printf(" | Shadow: %.1f", config.shadow);
+    if (fabs(config.shadow) < EPS)
     {
         printf("(disable)");
     }

--- a/Config/Config.h
+++ b/Config/Config.h
@@ -58,8 +58,8 @@ struct Configurations
     int fontsize;      /* 字号 */
     char fontname[FONTNAME_LEN]; /* 字体 */
     int opacity;       /* 不透明度 */
-    int outline;       /* 描边 */
-    int shadow;        /* 阴影 */
+    float outline;       /* 描边 */
+    float shadow;        /* 阴影 */
     BOOL bold;         /* 是否加粗 */
 
     BOOL saveBlockedPart;  /* 是否保存屏蔽部分 */

--- a/TemplateFile/TemplateFile.c
+++ b/TemplateFile/TemplateFile.c
@@ -784,7 +784,7 @@ int readTemplateFile(const char *const ipFile, const char *const templateFile,
             /* 没有定义的填充默认值 */
             if (readDanmaku->type == HAVE_NOT_BEEN_SET)
             {
-                readDanmaku->type == setType.defaultType;
+                readDanmaku->type = setType.defaultType;
             }
             if (readDanmaku->fontSize == HAVE_NOT_BEEN_SET)
             {

--- a/main.c
+++ b/main.c
@@ -373,7 +373,7 @@ int main(int argc, char **argv)
                 {
                     return 0;
                 }
-                config.outline = (int)returnValue;
+                config.outline = returnValue;
                 
                 argCnt += 2; 
             }
@@ -384,7 +384,7 @@ int main(int argc, char **argv)
                 {
                     return 0;
                 }
-                config.shadow = (int)returnValue;
+                config.shadow = returnValue;
                 
                 argCnt += 2; 
             }
@@ -764,17 +764,17 @@ int main(int argc, char **argv)
             return 0;
         }
         /* 描边 */
-        if (config.outline < 0 || config.outline > 4)
+        if (config.outline < 0.0 || config.outline > 4.0)
         {
             fprintf(stderr, "\nERROR"
-                            "\n\"Outline\" must be an integer greater than or equal to 0 and less than or equal to 4.\n");
+                            "\n\"Outline\" must be an float greater than or equal to 0 and less than or equal to 4.\n");
             return 0;
         }
         /* 阴影 */
-        if (config.shadow < 0 || config.shadow > 4)
+        if (config.shadow < 0.0|| config.shadow > 4.0)
         {
             fprintf(stderr, "\nERROR"
-                            "\n\"Shadow\" must be an integer greater than or equal to 0 and less than or equal to 4.\n");
+                            "\n\"Shadow\" must be an float greater than or equal to 0 and less than or equal to 4.\n");
             return 0;
         }
         /* 显示区域 */


### PR DESCRIPTION
这个PR主要做了一下工作：
1. 将描边和阴影的类型修改为 float
2. 礼物的描边和阴影根据弹幕的描边和阴影和字号比例进行换算，sc和舰长的描边和阴影为0（理由同之前的PR，有背景的情况下无需描边和阴影）
3. 修正一个typo