### PR TITLE
优化录播姬xml转换为ass的性能

### DIFF
--- a/XmlFile.c
+++ b/XmlFile.c
@@ -732,88 +732,59 @@ int writeXml(char const *const fileName, DANMAKU *danmakuHead, STATUS *const sta
   */
 static char *xmlUnescape(char *const str)
 {
-    /* 非法检查 */
     if (str == NULL)
     {
         return NULL;
     }
 
-    char *leftPtr, *rightPtr, *reWritePtr;
-    leftPtr = str;
-    while (*leftPtr != '\0')
+    char *srcPtr = str; // 源字符串指针
+    char *dstPtr = str; // 目标字符串指针，也用于就地修改字符串
+
+    while (*srcPtr != '\0')
     {
-        if (*leftPtr == '&')
+        if (*srcPtr == '&')
         {
-            if (strstr(leftPtr, "&amp;") == leftPtr)
+            if (strncmp(srcPtr, "&amp;", 5) == 0)
             {
-                *leftPtr = '&';
-                reWritePtr = leftPtr + 1;
-                rightPtr = leftPtr + 5;
-                while (*rightPtr != '\0')
-                {
-                    *reWritePtr = *rightPtr;
-                    reWritePtr++;
-                    rightPtr++;
-                }
-                *reWritePtr = '\0';
+                *dstPtr++ = '&';
+                srcPtr += 5;
             }
-            else if (strstr(leftPtr, "&apos;") == leftPtr)
+            else if (strncmp(srcPtr, "&apos;", 6) == 0)
             {
-                *leftPtr = '\'';
-                reWritePtr = leftPtr + 1;
-                rightPtr = leftPtr + 6;
-                while (*rightPtr != '\0')
-                {
-                    *reWritePtr = *rightPtr;
-                    reWritePtr++;
-                    rightPtr++;
-                }
-                *reWritePtr = '\0';
+                *dstPtr++ = '\'';
+                srcPtr += 6;
             }
-            else if (strstr(leftPtr, "&gt;") == leftPtr)
+            else if (strncmp(srcPtr, "&gt;", 4) == 0)
             {
-                *leftPtr = '>';
-                reWritePtr = leftPtr + 1;
-                rightPtr = leftPtr + 4;
-                while (*rightPtr != '\0')
-                {
-                    *reWritePtr = *rightPtr;
-                    reWritePtr++;
-                    rightPtr++;
-                }
-                *reWritePtr = '\0';
+                *dstPtr++ = '>';
+                srcPtr += 4;
             }
-            else if (strstr(leftPtr, "&lt;") == leftPtr)
+            else if (strncmp(srcPtr, "&lt;", 4) == 0)
             {
-                *leftPtr = '<';
-                reWritePtr = leftPtr + 1;
-                rightPtr = leftPtr + 4;
-                while (*rightPtr != '\0')
-                {
-                    *reWritePtr = *rightPtr;
-                    reWritePtr++;
-                    rightPtr++;
-                }
-                *reWritePtr = '\0';
+                *dstPtr++ = '<';
+                srcPtr += 4;
             }
-            else if (strstr(leftPtr, "&quot;") == leftPtr)
+            else if (strncmp(srcPtr, "&quot;", 6) == 0)
             {
-                *leftPtr = '\"';
-                reWritePtr = leftPtr + 1;
-                rightPtr = leftPtr + 6;
-                while (*rightPtr != '\0')
-                {
-                    *reWritePtr = *rightPtr;
-                    reWritePtr++;
-                    rightPtr++;
-                }
-                *reWritePtr = '\0';
+                *dstPtr++ = '\"';
+                srcPtr += 6;
+            }
+            else
+            {
+                // 如果不是已知的转义序列，就原样复制
+                *dstPtr++ = *srcPtr++;
             }
         }
-        
-        leftPtr++;
+        else
+        {
+            // 如果当前字符不是 '&'，就原样复制
+            *dstPtr++ = *srcPtr++;
+        }
     }
-    
+
+    // 字符串结束
+    *dstPtr = '\0';
+
     return str;
 }
 

--- a/XmlFile.c
+++ b/XmlFile.c
@@ -742,42 +742,41 @@ static char *xmlUnescape(char *const str)
 
     while (*srcPtr != '\0')
     {
-        if (*srcPtr == '&')
+        if (*srcPtr != '&')
         {
-            if (strncmp(srcPtr, "&amp;", 5) == 0)
-            {
-                *dstPtr++ = '&';
-                srcPtr += 5;
-            }
-            else if (strncmp(srcPtr, "&apos;", 6) == 0)
-            {
-                *dstPtr++ = '\'';
-                srcPtr += 6;
-            }
-            else if (strncmp(srcPtr, "&gt;", 4) == 0)
-            {
-                *dstPtr++ = '>';
-                srcPtr += 4;
-            }
-            else if (strncmp(srcPtr, "&lt;", 4) == 0)
-            {
-                *dstPtr++ = '<';
-                srcPtr += 4;
-            }
-            else if (strncmp(srcPtr, "&quot;", 6) == 0)
-            {
-                *dstPtr++ = '\"';
-                srcPtr += 6;
-            }
-            else
-            {
-                // 如果不是已知的转义序列，就原样复制
-                *dstPtr++ = *srcPtr++;
-            }
+            // 如果当前字符不是 '&'，就原样复制
+            *dstPtr++ = *srcPtr++;
+            continue;
+        }
+
+        if (strncmp(srcPtr, "&amp;", 5) == 0)
+        {
+            *dstPtr++ = '&';
+            srcPtr += 5;
+        }
+        else if (strncmp(srcPtr, "&apos;", 6) == 0)
+        {
+            *dstPtr++ = '\'';
+            srcPtr += 6;
+        }
+        else if (strncmp(srcPtr, "&gt;", 4) == 0)
+        {
+            *dstPtr++ = '>';
+            srcPtr += 4;
+        }
+        else if (strncmp(srcPtr, "&lt;", 4) == 0)
+        {
+            *dstPtr++ = '<';
+            srcPtr += 4;
+        }
+        else if (strncmp(srcPtr, "&quot;", 6) == 0)
+        {
+            *dstPtr++ = '\"';
+            srcPtr += 6;
         }
         else
         {
-            // 如果当前字符不是 '&'，就原样复制
+            // 如果不是已知的转义序列，就原样复制
             *dstPtr++ = *srcPtr++;
         }
     }

--- a/XmlFile.c
+++ b/XmlFile.c
@@ -116,7 +116,7 @@ int readXml(const char *const ipFile, DANMAKU **head, const char *mode, const fl
     BOOL isDanmaku;
     BOOL hasUserInfo;
     BOOL hasGiftInfo;
-    
+
     while (!feof(ipF))
     {
         type = 0;
@@ -284,62 +284,71 @@ int readXml(const char *const ipFile, DANMAKU **head, const char *mode, const fl
             // BililiveRecorder
             else if (strcmp(key, "raw") == 0)
             {
-                strGetLeftPart(NULL, &labelPtr, '\"', LABEL_LEN);
-                strGetLeftPart(raw, &labelPtr, '\"', LABEL_LEN);
-
-                /* 解析raw部分 */
-                char rawKey[KEY_LEN];
-                char rawValue[VALUE_LEN];
-                char *rawPtr = raw;
-
-                char coinTypeValue[VALUE_LEN] = {0};
-
-                xmlUnescape(raw);
-                strGetLeftPart(NULL, &rawPtr, '{', LABEL_LEN);
-
-                while (*rawPtr != '\0')
+                if(hasGiftInfo == TRUE) 
                 {
-                    strGetLeftPart(rawKey, &rawPtr, ':', KEY_LEN);
-                    strGetLeftPart(rawValue, &rawPtr, ',', VALUE_LEN);
-                    deQuotMarks(rawKey);
-                    deQuotMarks(rawValue);
-                    if (strcmp(rawKey, "gift_name") == 0)
+                    strGetLeftPart(NULL, &labelPtr, '\"', LABEL_LEN);
+                    strGetLeftPart(raw, &labelPtr, '\"', LABEL_LEN);
+
+                    /* 解析raw部分 */
+                    char rawKey[KEY_LEN];
+                    char rawValue[VALUE_LEN];
+                    char *rawPtr = raw;
+
+                    char coinTypeValue[VALUE_LEN] = {0};
+            clock_t start2 = clock();
+
+                    xmlUnescape(raw);
+                                            clock_t end2 = clock();
+            duration2 += (double)(end2 - start2) / CLOCKS_PER_SEC; 
+                    strGetLeftPart(NULL, &rawPtr, '{', LABEL_LEN);
+
+
+                    while (*rawPtr != '\0')
                     {
-                        strSafeCopy(gift.name, rawValue, GIFT_NAME_LEN);
-                    }
-                    else if (strcmp(rawKey, "coin_type") == 0)
-                    {
-                        strSafeCopy(coinTypeValue, rawValue, GIFT_NAME_LEN);
-                    }
-                    else if (strcmp(rawKey, "uid") == 0)
-                    {
-                        if (user.uid == 0) {
-                            user.uid = strtoull(rawValue, NULL, 10);
-                        }
-                    }
-                    else if (strcmp(rawKey, "price") == 0)
-                    {
-                        if (FLOAT_IS_EQUAL(gift.price, -1.00))
+                        strGetLeftPart(rawKey, &rawPtr, ':', KEY_LEN);
+                        strGetLeftPart(rawValue, &rawPtr, ',', VALUE_LEN);
+                        deQuotMarks(rawKey);
+                        deQuotMarks(rawValue);
+                        if (strcmp(rawKey, "gift_name") == 0)
                         {
-                            gift.price = atof(rawValue);
+                            strSafeCopy(gift.name, rawValue, GIFT_NAME_LEN);
+                        }
+                        else if (strcmp(rawKey, "coin_type") == 0)
+                        {
+                            strSafeCopy(coinTypeValue, rawValue, GIFT_NAME_LEN);
+                        }
+                        else if (strcmp(rawKey, "uid") == 0)
+                        {
+                            if (user.uid == 0) {
+                                user.uid = strtoull(rawValue, NULL, 10);
+                            }
+                        }
+                        else if (strcmp(rawKey, "price") == 0)
+                        {
+                            if (FLOAT_IS_EQUAL(gift.price, -1.00))
+                            {
+                                gift.price = atof(rawValue);
+                            }
+                        }
+                        else if (strcmp(rawKey, "combo_stay_time") == 0)
+                        {
+                            if (gift.duration == 0) {
+                                gift.duration = GET_MS_FLT(atof(rawValue));
+                            }
                         }
                     }
-                    else if (strcmp(rawKey, "combo_stay_time") == 0)
+
+                    if (strcmp(coinTypeValue, "silver") == 0)
                     {
-                        if (gift.duration == 0) {
-                            gift.duration = GET_MS_FLT(atof(rawValue));
-                        }
+                        giftPriceUnit = 0.0;
                     }
+                    else if (messageType != MSG_SUPER_CHAT)
+                    {
+                        giftPriceUnit = 1e-3;
+                    }
+                            
                 }
 
-                if (strcmp(coinTypeValue, "silver") == 0)
-                {
-                    giftPriceUnit = 0.0;
-                }
-                else if (messageType != MSG_SUPER_CHAT)
-                {
-                    giftPriceUnit = 1e-3;
-                }
             }
             // blrec
             else if (strcmp(key, "cointype") == 0) {

--- a/XmlFile.c
+++ b/XmlFile.c
@@ -295,13 +295,8 @@ int readXml(const char *const ipFile, DANMAKU **head, const char *mode, const fl
                     char *rawPtr = raw;
 
                     char coinTypeValue[VALUE_LEN] = {0};
-            clock_t start2 = clock();
-
                     xmlUnescape(raw);
-                                            clock_t end2 = clock();
-            duration2 += (double)(end2 - start2) / CLOCKS_PER_SEC; 
                     strGetLeftPart(NULL, &rawPtr, '{', LABEL_LEN);
-
 
                     while (*rawPtr != '\0')
                     {


### PR DESCRIPTION
https://github.com/hihkm/DanmakuFactory/issues/67

只在`hasGiftInfo=TRUE`时对弹幕姬的raw字段进行解析。

由于这段代码看起来只会在`hasGiftInfo=TRUE`有所用处，所以加了一个if来跳过其他标签，我c语言和项目的理解有限，修改可能影响到其他功能。

更好的解决方案可能是对`xmlUnescape`函数的性能进行优化