### PR TITLE
修复sc和舰长的金额错误

### DIFF
--- a/XmlFile.c
+++ b/XmlFile.c
@@ -358,7 +358,7 @@ int readXml(const char *const ipFile, DANMAKU **head, const char *mode, const fl
             }
         }
 
-        if (messageType == MSG_GIFT)
+        if (hasGiftInfo == TRUE)
         {
             gift.price *= giftPriceUnit;
         }

--- a/XmlFile.c
+++ b/XmlFile.c
@@ -358,7 +358,7 @@ int readXml(const char *const ipFile, DANMAKU **head, const char *mode, const fl
             }
         }
 
-        if (hasGiftInfo == TRUE)
+        if (hasGiftInfo == TRUE && messageType != MSG_SUPER_CHAT)
         {
             gift.price *= giftPriceUnit;
         }


### PR DESCRIPTION
在`messageType=MSG_SUPER_CHAT`以及`messageType=MSG_GUARD`时也对金额乘以相应基数。

这个bug会导致sc和上舰的相关颜色计算错误，以及影响`giftminprice`的计算
![图片](https://github.com/user-attachments/assets/b7885385-2c47-4e21-b829-306939909464)
