### PR TITLE
Blrec适配修复

### DIFF
--- a/AssFile/AssFile.c
+++ b/AssFile/AssFile.c
@@ -1740,6 +1740,7 @@ int writeAssDanmakuPart(FILE *opF, DANMAKU *head, CONFIG config, STATUS *const s
     COORDIN msgBoxPos = config.msgBoxPos;
     int msgFontSize = config.msgboxFontsize;
     const int msgDuration = GET_ASS_MS_FLT(config.msgboxDuration);  // 精度为 10 毫秒
+    const int giftMinPrice = config.giftMinPrice * 1000.0f;         // 单位：厘
     const BOOL giftComboSwitch = GET_ASS_MS_FLT(config.giftMergeTolerance) >= 0;
 
     /* 刷新status */
@@ -2336,7 +2337,7 @@ int writeAssDanmakuPart(FILE *opF, DANMAKU *head, CONFIG config, STATUS *const s
         else if (IS_MSG(now) && showMsgBox)/* 消息 */
         {
             /* 按最低价格屏蔽 */
-            if (now->gift->price < config.giftMinPrice && now->gift->price > -EPS)
+            if (now->gift->price < giftMinPrice && now->gift->price >= 0)
             {
                 goto NEXTNODE;
             }
@@ -3310,13 +3311,13 @@ int printMessage(FILE *filePtr,
 
         strcpy(textColor, "\\c&H313131");
 
-        if (message->gift->price + EPS > 2000)
+        if (message->gift->price >= 2000 * 1000)
         { /* 2k及以上 */
             strcpy(topBoxColor, "\\c&HD8D8FF");
             strcpy(btmBoxColor, "\\c&H321AAB");
             strcpy(userIDColor, "\\c&H1B0E5E");
         }
-        else if (message->gift->price + EPS > 1000)
+        else if (message->gift->price >= 1000 * 1000)
         { /* 1k及以上 */
             // strcpy(topBoxColor, "\\c&HE5E5FF");
             // strcpy(btmBoxColor, "\\c&H8C8CF7");
@@ -3325,7 +3326,7 @@ int printMessage(FILE *filePtr,
             strcpy(btmBoxColor, "\\c&H4D4DE5");
             strcpy(userIDColor, "\\c&H333398");
         }
-        else if (message->gift->price + EPS > 500)
+        else if (message->gift->price >= 500 * 1000)
         { /* 500及以上 */
             // strcpy(topBoxColor, "\\c&HD4F6FF");
             // strcpy(btmBoxColor, "\\c&H8CCEF7");
@@ -3334,7 +3335,7 @@ int printMessage(FILE *filePtr,
             strcpy(btmBoxColor, "\\c&H4394E0");
             strcpy(userIDColor, "\\c&H2C6193");
         }
-        else if (message->gift->price + EPS > 100)
+        else if (message->gift->price >= 100 * 1000)
         { /* 100及以上 */
             // strcpy(topBoxColor, "\\c&HCAF9F8");
             // strcpy(btmBoxColor, "\\c&H76E8E9");
@@ -3343,7 +3344,7 @@ int printMessage(FILE *filePtr,
             strcpy(btmBoxColor, "\\c&H2BB5E2");
             strcpy(userIDColor, "\\c&H1C7795");
         }
-        else if (message->gift->price + EPS > 50)
+        else if (message->gift->price >= 50 * 1000)
         { /* 50及以上 */
             strcpy(topBoxColor, "\\c&HFDFFDB");
             strcpy(btmBoxColor, "\\c&H9E7D42");
@@ -3413,7 +3414,7 @@ int printMessage(FILE *filePtr,
             effect, /* 补充特效 */
             textColor, /* 颜色 */
             (int)(fontSize*(4.0/5.0)), /* 金额文字大小 */
-            (int)message->gift->price /* SC金额 */
+            message->gift->price / 1000/* SC金额 */
         );
 
         /* SC内容 */
@@ -3436,12 +3437,12 @@ int printMessage(FILE *filePtr,
         char textColor[ASS_COLOR_LEN];
 
         strcpy(textColor, "\\c&H313131");
-        if (message->gift->price + EPS > 19800)
+        if (message->gift->price >= 19998 * 1000)
         { /* 总督 */
             strcpy(boxColor, "\\c&HE5E5FF");
             strcpy(userIDColor, "\\c&H0F0F75");
         }
-        else if (message->gift->price + EPS > 1980)
+        else if (message->gift->price >= 1998 * 1000)
         { /* 提督 */
             strcpy(boxColor, "\\c&HCAF9F8");
             strcpy(userIDColor, "\\c&H1A8B87");

--- a/Config/Config.h
+++ b/Config/Config.h
@@ -70,7 +70,7 @@ struct Configurations
     struct Coordinate msgBoxPos;  /* 消息框位置 */
     int msgboxFontsize;           /* 消息框内文字大小 */
     float msgboxDuration;         /* 消息框持续时长(秒数) */
-    float giftMinPrice;           /* 消息框礼物最低价格限制 */
+    float giftMinPrice;           /* 消息框礼物最低价格限制(元) */
     float giftMergeTolerance;     /* 相同用户相同礼物合并时间窗(秒数) */
 
     int blockmode;     /* 屏蔽模式 */

--- a/Define/DanmakuDef.h
+++ b/Define/DanmakuDef.h
@@ -111,7 +111,7 @@ struct UserPart
 struct GiftPart
 {
     char name[GIFT_NAME_LEN];
-    float price;
+    int price;      // 礼物金额(厘)
     int count;
     int duration;   // 持续时间(毫秒)
 };

--- a/XmlFile.c
+++ b/XmlFile.c
@@ -732,88 +732,59 @@ int writeXml(char const *const fileName, DANMAKU *danmakuHead, STATUS *const sta
   */
 static char *xmlUnescape(char *const str)
 {
-    /* 非法检查 */
     if (str == NULL)
     {
         return NULL;
     }
 
-    char *leftPtr, *rightPtr, *reWritePtr;
-    leftPtr = str;
-    while (*leftPtr != '\0')
+    char *srcPtr = str; // 源字符串指针
+    char *dstPtr = str; // 目标字符串指针，也用于就地修改字符串
+
+    while (*srcPtr != '\0')
     {
-        if (*leftPtr == '&')
+        if (*srcPtr == '&')
         {
-            if (strstr(leftPtr, "&amp;") == leftPtr)
+            if (strncmp(srcPtr, "&amp;", 5) == 0)
             {
-                *leftPtr = '&';
-                reWritePtr = leftPtr + 1;
-                rightPtr = leftPtr + 5;
-                while (*rightPtr != '\0')
-                {
-                    *reWritePtr = *rightPtr;
-                    reWritePtr++;
-                    rightPtr++;
-                }
-                *reWritePtr = '\0';
+                *dstPtr++ = '&';
+                srcPtr += 5;
             }
-            else if (strstr(leftPtr, "&apos;") == leftPtr)
+            else if (strncmp(srcPtr, "&apos;", 6) == 0)
             {
-                *leftPtr = '\'';
-                reWritePtr = leftPtr + 1;
-                rightPtr = leftPtr + 6;
-                while (*rightPtr != '\0')
-                {
-                    *reWritePtr = *rightPtr;
-                    reWritePtr++;
-                    rightPtr++;
-                }
-                *reWritePtr = '\0';
+                *dstPtr++ = '\'';
+                srcPtr += 6;
             }
-            else if (strstr(leftPtr, "&gt;") == leftPtr)
+            else if (strncmp(srcPtr, "&gt;", 4) == 0)
             {
-                *leftPtr = '>';
-                reWritePtr = leftPtr + 1;
-                rightPtr = leftPtr + 4;
-                while (*rightPtr != '\0')
-                {
-                    *reWritePtr = *rightPtr;
-                    reWritePtr++;
-                    rightPtr++;
-                }
-                *reWritePtr = '\0';
+                *dstPtr++ = '>';
+                srcPtr += 4;
             }
-            else if (strstr(leftPtr, "&lt;") == leftPtr)
+            else if (strncmp(srcPtr, "&lt;", 4) == 0)
             {
-                *leftPtr = '<';
-                reWritePtr = leftPtr + 1;
-                rightPtr = leftPtr + 4;
-                while (*rightPtr != '\0')
-                {
-                    *reWritePtr = *rightPtr;
-                    reWritePtr++;
-                    rightPtr++;
-                }
-                *reWritePtr = '\0';
+                *dstPtr++ = '<';
+                srcPtr += 4;
             }
-            else if (strstr(leftPtr, "&quot;") == leftPtr)
+            else if (strncmp(srcPtr, "&quot;", 6) == 0)
             {
-                *leftPtr = '\"';
-                reWritePtr = leftPtr + 1;
-                rightPtr = leftPtr + 6;
-                while (*rightPtr != '\0')
-                {
-                    *reWritePtr = *rightPtr;
-                    reWritePtr++;
-                    rightPtr++;
-                }
-                *reWritePtr = '\0';
+                *dstPtr++ = '\"';
+                srcPtr += 6;
+            }
+            else
+            {
+                // 如果不是已知的转义序列，就原样复制
+                *dstPtr++ = *srcPtr++;
             }
         }
-        
-        leftPtr++;
+        else
+        {
+            // 如果当前字符不是 '&'，就原样复制
+            *dstPtr++ = *srcPtr++;
+        }
     }
-    
+
+    // 字符串结束
+    *dstPtr = '\0';
+
     return str;
 }
 

--- a/XmlFile.c
+++ b/XmlFile.c
@@ -345,10 +345,11 @@ int readXml(const char *const ipFile, DANMAKU **head, const char *mode, const fl
                 }
 
             }
-            // blrec
+            // blrec的礼物，不包含sc和guard
             else if (strcmp(key, "cointype") == 0) {
                 char coinTypeValue[VALUE_LEN];
                 getNextWord(&labelPtr, coinTypeValue, GIFT_NAME_LEN, ' ', TRUE);
+                deQuotMarks(coinTypeValue);
                 if (strcmp(coinTypeValue, "\xe9\x93\xb6\xe7\x93\x9c\xe5\xad\x90") == 0) {
                     giftPriceUnit = 0.0;
                 }

--- a/XmlFile.c
+++ b/XmlFile.c
@@ -742,42 +742,41 @@ static char *xmlUnescape(char *const str)
 
     while (*srcPtr != '\0')
     {
-        if (*srcPtr == '&')
+        if (*srcPtr != '&')
         {
-            if (strncmp(srcPtr, "&amp;", 5) == 0)
-            {
-                *dstPtr++ = '&';
-                srcPtr += 5;
-            }
-            else if (strncmp(srcPtr, "&apos;", 6) == 0)
-            {
-                *dstPtr++ = '\'';
-                srcPtr += 6;
-            }
-            else if (strncmp(srcPtr, "&gt;", 4) == 0)
-            {
-                *dstPtr++ = '>';
-                srcPtr += 4;
-            }
-            else if (strncmp(srcPtr, "&lt;", 4) == 0)
-            {
-                *dstPtr++ = '<';
-                srcPtr += 4;
-            }
-            else if (strncmp(srcPtr, "&quot;", 6) == 0)
-            {
-                *dstPtr++ = '\"';
-                srcPtr += 6;
-            }
-            else
-            {
-                // 如果不是已知的转义序列，就原样复制
-                *dstPtr++ = *srcPtr++;
-            }
+            // 如果当前字符不是 '&'，就原样复制
+            *dstPtr++ = *srcPtr++;
+            continue;
+        }
+
+        if (strncmp(srcPtr, "&amp;", 5) == 0)
+        {
+            *dstPtr++ = '&';
+            srcPtr += 5;
+        }
+        else if (strncmp(srcPtr, "&apos;", 6) == 0)
+        {
+            *dstPtr++ = '\'';
+            srcPtr += 6;
+        }
+        else if (strncmp(srcPtr, "&gt;", 4) == 0)
+        {
+            *dstPtr++ = '>';
+            srcPtr += 4;
+        }
+        else if (strncmp(srcPtr, "&lt;", 4) == 0)
+        {
+            *dstPtr++ = '<';
+            srcPtr += 4;
+        }
+        else if (strncmp(srcPtr, "&quot;", 6) == 0)
+        {
+            *dstPtr++ = '\"';
+            srcPtr += 6;
         }
         else
         {
-            // 如果当前字符不是 '&'，就原样复制
+            // 如果不是已知的转义序列，就原样复制
             *dstPtr++ = *srcPtr++;
         }
     }

--- a/XmlFile.c
+++ b/XmlFile.c
@@ -261,27 +261,32 @@ int readXml(const char *const ipFile, DANMAKU **head, const char *mode, const fl
             else if (strcmp(key, "level") == 0)
             {
                 getNextWord(&labelPtr, tempText, MAX_TEXT_LENGTH, ' ', TRUE);
+                giftPriceUnit = 1;
                 switch (atoi(deQuotMarks(tempText)))
                 {
                 case 1:
                     // 总督
                     gift.duration = 19998000;
+                    gift.price = 19998;
                     break;
                 case 2:
                     // 提督
                     gift.duration = 1998000;
+                    gift.price = 1998;
                     break;
                 case 3:
                     // 舰长
                     gift.duration = 198000;
+                    gift.price = 198;
                     break;
                 default:
                     // 未知
                     gift.duration = 18000;
+                    gift.price = 0;
                     break;
                 }
             }
-            // BililiveRecorder
+            // BililiveRecorder，开启记录raw
             else if (strcmp(key, "raw") == 0)
             {
                 if(hasGiftInfo == TRUE) 

--- a/XmlFile.c
+++ b/XmlFile.c
@@ -116,7 +116,7 @@ int readXml(const char *const ipFile, DANMAKU **head, const char *mode, const fl
     BOOL isDanmaku;
     BOOL hasUserInfo;
     BOOL hasGiftInfo;
-    
+
     while (!feof(ipF))
     {
         type = 0;
@@ -284,62 +284,71 @@ int readXml(const char *const ipFile, DANMAKU **head, const char *mode, const fl
             // BililiveRecorder
             else if (strcmp(key, "raw") == 0)
             {
-                strGetLeftPart(NULL, &labelPtr, '\"', LABEL_LEN);
-                strGetLeftPart(raw, &labelPtr, '\"', LABEL_LEN);
-
-                /* 解析raw部分 */
-                char rawKey[KEY_LEN];
-                char rawValue[VALUE_LEN];
-                char *rawPtr = raw;
-
-                char coinTypeValue[VALUE_LEN] = {0};
-
-                xmlUnescape(raw);
-                strGetLeftPart(NULL, &rawPtr, '{', LABEL_LEN);
-
-                while (*rawPtr != '\0')
+                if(hasGiftInfo == TRUE) 
                 {
-                    strGetLeftPart(rawKey, &rawPtr, ':', KEY_LEN);
-                    strGetLeftPart(rawValue, &rawPtr, ',', VALUE_LEN);
-                    deQuotMarks(rawKey);
-                    deQuotMarks(rawValue);
-                    if (strcmp(rawKey, "gift_name") == 0)
+                    strGetLeftPart(NULL, &labelPtr, '\"', LABEL_LEN);
+                    strGetLeftPart(raw, &labelPtr, '\"', LABEL_LEN);
+
+                    /* 解析raw部分 */
+                    char rawKey[KEY_LEN];
+                    char rawValue[VALUE_LEN];
+                    char *rawPtr = raw;
+
+                    char coinTypeValue[VALUE_LEN] = {0};
+            clock_t start2 = clock();
+
+                    xmlUnescape(raw);
+                                            clock_t end2 = clock();
+            duration2 += (double)(end2 - start2) / CLOCKS_PER_SEC; 
+                    strGetLeftPart(NULL, &rawPtr, '{', LABEL_LEN);
+
+
+                    while (*rawPtr != '\0')
                     {
-                        strSafeCopy(gift.name, rawValue, GIFT_NAME_LEN);
-                    }
-                    else if (strcmp(rawKey, "coin_type") == 0)
-                    {
-                        strSafeCopy(coinTypeValue, rawValue, GIFT_NAME_LEN);
-                    }
-                    else if (strcmp(rawKey, "uid") == 0)
-                    {
-                        if (user.uid == 0) {
-                            user.uid = strtoull(rawValue, NULL, 10);
-                        }
-                    }
-                    else if (strcmp(rawKey, "price") == 0)
-                    {
-                        if (FLOAT_IS_EQUAL(gift.price, -1.00))
+                        strGetLeftPart(rawKey, &rawPtr, ':', KEY_LEN);
+                        strGetLeftPart(rawValue, &rawPtr, ',', VALUE_LEN);
+                        deQuotMarks(rawKey);
+                        deQuotMarks(rawValue);
+                        if (strcmp(rawKey, "gift_name") == 0)
                         {
-                            gift.price = atof(rawValue);
+                            strSafeCopy(gift.name, rawValue, GIFT_NAME_LEN);
+                        }
+                        else if (strcmp(rawKey, "coin_type") == 0)
+                        {
+                            strSafeCopy(coinTypeValue, rawValue, GIFT_NAME_LEN);
+                        }
+                        else if (strcmp(rawKey, "uid") == 0)
+                        {
+                            if (user.uid == 0) {
+                                user.uid = strtoull(rawValue, NULL, 10);
+                            }
+                        }
+                        else if (strcmp(rawKey, "price") == 0)
+                        {
+                            if (FLOAT_IS_EQUAL(gift.price, -1.00))
+                            {
+                                gift.price = atof(rawValue);
+                            }
+                        }
+                        else if (strcmp(rawKey, "combo_stay_time") == 0)
+                        {
+                            if (gift.duration == 0) {
+                                gift.duration = GET_MS_FLT(atof(rawValue));
+                            }
                         }
                     }
-                    else if (strcmp(rawKey, "combo_stay_time") == 0)
+
+                    if (strcmp(coinTypeValue, "silver") == 0)
                     {
-                        if (gift.duration == 0) {
-                            gift.duration = GET_MS_FLT(atof(rawValue));
-                        }
+                        giftPriceUnit = 0.0;
                     }
+                    else if (messageType != MSG_SUPER_CHAT)
+                    {
+                        giftPriceUnit = 1e-3;
+                    }
+                            
                 }
 
-                if (strcmp(coinTypeValue, "silver") == 0)
-                {
-                    giftPriceUnit = 0.0;
-                }
-                else if (messageType != MSG_SUPER_CHAT)
-                {
-                    giftPriceUnit = 1e-3;
-                }
             }
             // blrec
             else if (strcmp(key, "cointype") == 0) {

--- a/XmlFile.c
+++ b/XmlFile.c
@@ -295,13 +295,8 @@ int readXml(const char *const ipFile, DANMAKU **head, const char *mode, const fl
                     char *rawPtr = raw;
 
                     char coinTypeValue[VALUE_LEN] = {0};
-            clock_t start2 = clock();
-
                     xmlUnescape(raw);
-                                            clock_t end2 = clock();
-            duration2 += (double)(end2 - start2) / CLOCKS_PER_SEC; 
                     strGetLeftPart(NULL, &rawPtr, '{', LABEL_LEN);
-
 
                     while (*rawPtr != '\0')
                     {


### PR DESCRIPTION
修复blrec的舰长和礼物价格 #53。

但是未对sc的价格进行修复，我没找到有什么有效字段来判断这是blrec文件。
录播姬倒是可以通过包含`<BililiveRecorder`字符来判断，要实现的话可以在sc标签中默认`giftPriceUnit=1e-3`，为录播姬设置为`giftPriceUnit=1`，但这样可能破坏除这两者之外的bilibili弹幕录制文件。
![图片](https://github.com/user-attachments/assets/5479d87c-81e6-4194-b9a2-67c3001d582f)


测试文件：[test.zip](https://github.com/user-attachments/files/16369664/test.zip)
