### PR TITLE
build: 优化构建相关配置

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,8 +2,6 @@ name: Build
 
 on:
   push:
-    branches:
-      - master
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  prebuild:
+  build:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     env:
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest, ubuntu-24.04-arm]
 
     steps:
       - name: Check out Git repository
@@ -31,42 +31,16 @@ jobs:
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: startsWith(matrix.os, 'windows')
         with:
-          name: package-${{ runner.os }}
+          name: package-${{ runner.os }}-${{ runner.arch }}
           path: build/Release/DanmakuFactory.exe
-  
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
-        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'  }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos') }}
         with:
-          name: package-${{ runner.os }}
-          path: build/DanmakuFactory
-
-
-  prebuild-linux-arm:
-    strategy:
-      matrix:
-        arch:
-          - arm64
-    name: Prebuild on Linux (${{ matrix.arch }})
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: 'recursive'
-      - uses: docker/setup-qemu-action@v3
-      - run: |
-          docker run --rm -v $(pwd):/tmp/project --entrypoint /bin/sh --platform linux/${{ matrix.arch }} ubuntu:latest -c "\
-          apt-get update && \
-          apt-get install -y make gcc cmake && \
-          cd /tmp/project && \
-          cmake -S . -B build && \
-          cmake --build build --target DanmakuFactory"
-      - name: Upload arm64 artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: package-linux-${{ matrix.arch }}
+          name: package-${{ runner.os }}-${{ runner.arch }}
           path: build/DanmakuFactory
 
 permissions:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15...4.0)
 
-project(DanmakuFactory C)
+project(DanmakuFactory LANGUAGES C)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 


### PR DESCRIPTION
本次 PR 主要是对 CI/CD 流水线和构建配置的少量优化。

* `.github/workflows/release.yaml`：
  - 移除了单独的 `prebuild-linux-arm` 任务，使用了 [GitHub Action arm64 运行器](https://docs.github.com/zh/actions/how-tos/writing-workflows/choosing-where-your-workflow-runs/choosing-the-runner-for-a-job#%E7%94%A8%E4%BA%8E%E5%85%AC%E5%85%B1%E5%AD%98%E5%82%A8%E5%BA%93%E7%9A%84-github-%E6%89%98%E7%AE%A1%E7%9A%84%E6%A0%87%E5%87%86%E8%BF%90%E8%A1%8C%E5%99%A8)，将 ARM64 支持整合进主构建矩阵，流程更加简洁高效。实测 arm64 平台上的构建时间从接近 6 分钟缩短到了 [30 秒](https://github.com/xiaoxuan010/DanmakuFactory/actions/runs/16521622302/job/46724578658)，总构建时长从 6 分钟缩短到了 1 分钟。

* `CMakeLists.txt`：
  - 最低 CMake 版本要求由单一版本改为区间（`3.15...4.0`），消除了一个 warning，且仍保证广泛的兼容性。