### PR TITLE
Update xmake.lua to consider POSIX

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -10,6 +10,7 @@ target("cli")
     set_basename(PROJECT_NAME)
     set_kind("binary")
     set_languages("c11")
+    add_defines("_POSIX_C_SOURCE=200809L")
     set_version("2.0.0", {build = "%Y%m%d%H%M"})
 
     add_files("src/*.c", "src/**/*.c")


### PR DESCRIPTION
`readlink()` needs to define correct macro for proper use under Linux. Otherwise xmake will complain error and fail to build on Linux.

Tested on Arch Linux with xmake v3.0.2+20250906

Please refer to: https://stackoverflow.com/questions/66862654/why-does-my-compiler-think-my-readlink-is-implicitly-declared-if-i-set-the-sta