### PR TITLE
style(xmake): 调整源文件添加顺序- 将 add_files 调整至 add_packages 之后- 保持代码逻辑顺序一致性

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -12,8 +12,8 @@ target("cli")
     set_languages("c11")
     set_version("2.0.0", {build = "%Y%m%d%H%M"})
 
-    add_files("src/*.c", "src/**/*.c")
     add_packages("pcre2")
+    add_files("src/*.c", "src/**/*.c")
 
     on_package(function (target)
         if is_mode("release") then


### PR DESCRIPTION
xmake尝试编译Android平台错误:
`
PS C:\Users\moli\CProject\DanmakuFactory> xmake f -p android --trybuild=autotools --ndk=C:\Users\moli\AppData\Local\Android\Sdk\ndk\27.0.12077973
checking for architecture ... armeabi-v7a
checking for Android SDK directory ... no
checking for NDK directory ... C:\Users\moli\AppData\Local\Android\Sdk\ndk\27.0.12077973
checking for SDK version of NDK ... 21
PS C:\Users\moli\CProject\DanmakuFactory> xmake
[ 59%]: cache compiling.release src\JsonFile.c
[ 59%]: cache compiling.release src\main.c
[ 59%]: cache compiling.release src\XmlFile.c
[ 59%]: cache compiling.release src\AssFile\AssStringProcessing.c
[ 59%]: cache compiling.release src\List\DanmakuFactoryList.c
[ 59%]: cache compiling.release src\Config\Config.c
[ 59%]: cache compiling.release src\AssFile\AssFile.c
[ 59%]: cache compiling.release src\TemplateFile\TemplateFile.c
[ 59%]: cache compiling.release src\String\DanmakuFactoryString.c
src\String\DanmakuFactoryString.c:65:16: warning: passing 'const unsigned char *' to parameter of type 'const char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Wpointer-sign]
   65 |     if (isUtf8(str) == TRUE)
      |                ^~~
src\String/DanmakuFactoryString.h:60:42: note: passing argument to parameter 'str' here
   60 |     extern BOOL isUtf8(char const *const str);
      |                                          ^
src\String\DanmakuFactoryString.c:92:27: warning: passing 'const unsigned char *' to parameter of type 'const char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Wpointer-sign]
   92 |         cnt = (int)strlen(str);
      |                           ^~~
C:\Users\moli\AppData\Local\Android\Sdk\ndk\27.0.12077973\toolchains\llvm\prebuilt\windows-x86_64\sysroot/usr/include/string.h:108:36: note: passing argument to parameter '__s' here
  108 | size_t strlen(const char* _Nonnull __s) __attribute_pure__;
      |                                    ^
src\String\DanmakuFactoryString.c:471:26: warning: initializing 'const unsigned char *' with an expression of type 'const char *const' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Wpointer-sign]
  471 |     const unsigned char *ptr = str;
      |                          ^     ~~~
3 warnings generated.
src\AssFile\AssFile.c:3396:24: warning: initializing 'unsigned char *' with an expression of type 'char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Wpointer-sign]
 3396 |         unsigned char *textPtr = message->text;
      |                        ^         ~~~~~~~~~~~~~
src\AssFile\AssFile.c:3455:19: warning: assigning to 'unsigned char *' from 'char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Wpointer-sign]
 3455 |         srcStrPtr = message->text;
      |                   ^ ~~~~~~~~~~~~~
2 warnings generated.
error: src\List\DanmakuFactoryList.c:27:10: fatal error: 'pcre2.h' file not found
   27 | #include <pcre2.h>
      |          ^~~~~~~~~
1 error generated.
  > in src\List\DanmakuFactoryList.c
`



修改后可以正常编译:


`
PS C:\Users\moli\CProject\DanmakuFactory> xmake
checking for Android SDK directory ... no
checking for NDK directory ... C:\Users\moli\AppData\Local\Android\Sdk\ndk\27.0.12077973
checking for SDK version of NDK ... 21
checking for Microsoft Visual Studio (x64) version ... 2022
[ 59%]: cache compiling.release src\JsonFile.c
[ 59%]: cache compiling.release src\main.c
[ 59%]: cache compiling.release src\TemplateFile\TemplateFile.c
[ 59%]: cache compiling.release src\String\DanmakuFactoryString.c
[ 59%]: cache compiling.release src\List\DanmakuFactoryList.c
[ 59%]: cache compiling.release src\Config\Config.c
[ 59%]: cache compiling.release src\AssFile\AssStringProcessing.c
[ 59%]: cache compiling.release src\AssFile\AssFile.c
[ 59%]: cache compiling.release src\XmlFile.c
src\String\DanmakuFactoryString.c:65:16: warning: passing 'const unsigned char *' to parameter of type 'const char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Wpointer-sign]
   65 |     if (isUtf8(str) == TRUE)
      |                ^~~
src\String/DanmakuFactoryString.h:60:42: note: passing argument to parameter 'str' here
   60 |     extern BOOL isUtf8(char const *const str);
      |                                          ^
src\String\DanmakuFactoryString.c:92:27: warning: passing 'const unsigned char *' to parameter of type 'const char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Wpointer-sign]
   92 |         cnt = (int)strlen(str);
      |                           ^~~
C:\Users\moli\AppData\Local\Android\Sdk\ndk\27.0.12077973\toolchains\llvm\prebuilt\windows-x86_64\sysroot/usr/include/string.h:108:36: note: passing argument to parameter '__s' here
  108 | size_t strlen(const char* _Nonnull __s) __attribute_pure__;
      |                                    ^
src\String\DanmakuFactoryString.c:471:26: warning: initializing 'const unsigned char *' with an expression of type 'const char *const' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Wpointer-sign]
  471 |     const unsigned char *ptr = str;
      |                          ^     ~~~
3 warnings generated.
src\AssFile\AssFile.c:3396:24: warning: initializing 'unsigned char *' with an expression of type 'char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Wpointer-sign]
 3396 |         unsigned char *textPtr = message->text;
      |                        ^         ~~~~~~~~~~~~~
src\AssFile\AssFile.c:3455:19: warning: assigning to 'unsigned char *' from 'char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Wpointer-sign]
 3455 |         srcStrPtr = message->text;
      |                   ^ ~~~~~~~~~~~~~
2 warnings generated.
[ 71%]: linking.release DanmakuFactory
[100%]: build ok, spent 1.266s
warning: we cannot load toolchain(zig), because it has been not checked yet!
`
