### PR TITLE
build: pcre2使用静态库来进行编译

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -4,7 +4,7 @@ add_rules("mode.debug", "mode.release")
 
 set_project(PROJECT_NAME)
 
-add_requires("pcre2")
+add_requires("pcre2", {configs = {shared = false}})
 
 target("cli")
     set_basename(PROJECT_NAME)


### PR DESCRIPTION
部分用户在MacOS上出现了缺少库的行为，使用静态库编译来避免这种问题的出现，压缩包体积约大了100KB

`Reason: tried: '/opt/homebrew/opt/pcre2/lib/libpcre2-8.0.dylib' (no such file)`